### PR TITLE
Optimist

### DIFF
--- a/exe/mypki
+++ b/exe/mypki
@@ -1,6 +1,6 @@
 #! /usr/bin/env ruby
 require 'mypki'
-require 'trollop'
+require 'optimist'
 
 args = []
 
@@ -15,7 +15,7 @@ while arg = ARGV.first
   end
 end
 
-options = Trollop::options args do
+options = Optimist::options args do
   version MyPKI::VERSION
   banner "MyPKI #{MyPKI::VERSION}: PKI-enables Ruby's OpenSSL libraries, which PKI-enables most libraries and gems written in Ruby.\n\nUSAGE:"
   opt :ssh, "Also configure ssh to use your PKI"
@@ -34,7 +34,7 @@ else
   ARGV.shift args.size 
   
   if ARGV.empty?
-    Trollop::die "you must specify a program or option"
+    Optimist::die "you must specify a program or option"
   end
   
   executable = ARGV.shift

--- a/lib/mypki/version.rb
+++ b/lib/mypki/version.rb
@@ -1,3 +1,3 @@
 module MyPKI
-  VERSION = "4.0.3"
+  VERSION = "4.0.4"
 end

--- a/mypki.gemspec
+++ b/mypki.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'multi_json'
-  spec.add_dependency 'trollop'
+  spec.add_dependency 'optimist'
   spec.add_dependency 'metaid'
   spec.add_dependency 'highline'
   spec.add_dependency 'retriable'


### PR DESCRIPTION
`trollop` has been deprecated and produces a runtime warning when used.

    [DEPRECATION] This gem has been renamed to optimist and will no longer be supported. Please switch to optimist as soon as possible.

This pull request switches to using `optimist`.

Fixes #5 